### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -6,9 +6,19 @@ const compress = require('./compress')
 const bypass = require('./bypass')
 const copyHeaders = require('./copyHeaders')
 
+const allowedUrls = {
+  'example1': 'https://example1.com/data',
+  'example2': 'https://example2.com/data'
+};
+
 function proxy(req, res) {
+  const targetUrl = allowedUrls[req.params.url];
+  if (!targetUrl) {
+    return res.status(400).send('Invalid URL parameter');
+  }
+
   request.get(
-    req.params.url,
+    targetUrl,
     {
       headers: {
         ...pick(req.headers, ['cookie', 'dnt', 'referer']),


### PR DESCRIPTION
Potential fix for [https://github.com/SSL-ACTX/SL-DTSVR-VC/security/code-scanning/1](https://github.com/SSL-ACTX/SL-DTSVR-VC/security/code-scanning/1)

To fix the problem, we need to ensure that the user input is not directly used to construct the URL for the outgoing request. Instead, we should use a whitelist of allowed URLs or domains to ensure that only valid and intended requests are made. This can be achieved by mapping user input to predefined, safe URLs.

1. Create a whitelist of allowed URLs or domains.
2. Map the user-provided `url` parameter to one of the allowed URLs.
3. Use the mapped URL in the `request.get` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
